### PR TITLE
Action refactoring and UI improvements

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,10 @@
       "Bash(git checkout:*)",
       "Bash(git add:*)",
       "Bash(git commit -m ':*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(git -C /home/nathanm412/Elgato-VUMeter log:*)",
+      "Bash(git -C /home/nathanm412/Elgato-VUMeter log:*)",
+      "Bash(git stash:*)"
     ],
     "deny": [
       "Bash(gh pr merge:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,13 @@ Event-driven pipeline with a single shared `AudioCapture` instance:
 ```
 AudioCapture  ──> emits 'levels' events at ~20fps
     │
-    ├──> VUMeterTwoRow.updateLevels()  (multi-key gradient bars)
-    ├──> VUMeterOneRow.updateLevels()  (split L/R per key)
+    ├──> VUMeterKeypad.updateLevels()  (two-row/one-row key modes)
+    ├──> VUMeterOneRow.updateLevels()  (legacy compat, hidden)
     └──> VUMeterTouch.updateLevels()   (800x100 touch strip)
 ```
 
-- **`src/plugin.ts`** — Entry point & orchestrator. Creates a single `AudioCapture`, rate-limits updates via `scheduleUpdate()`, and distributes levels to all active action instances concurrently.
-- **`src/actions/`** — Three action classes, one per display mode. Each dynamically computes segment count from the coordinates of active keys. Actions register with the Stream Deck SDK and handle key press / encoder events.
+- **`src/plugin.ts`** — Entry point & orchestrator. Creates a single `AudioCapture`, rate-limits updates via `scheduleUpdate()`, distributes levels to all active actions, and mediates cross-action theme sync.
+- **`src/actions/`** — `VUMeterKeypad` (consolidated keypad action with two-row/one-row mode dropdown), `VUMeterOneRow` (legacy compat, hidden from action list), and `VUMeterTouch` (encoder touch strip). Each dynamically computes segment count from active key coordinates.
 - **`src/audio/audio-capture.ts`** — Cross-platform audio capture. Uses platform-specific helper scripts: WASAPI loopback (PowerShell) on Windows, CoreAudio (shell script) on macOS. Emits normalized `AudioLevels` events.
 - **`src/rendering/`** — SVG generators. `key-renderer.ts` renders gradient fill bars (vertical + horizontal orientation). `touch-renderer.ts` renders the full-width touch strip with dB scale markings.
 - **`src/utils/color.ts`** — Four color themes (Classic, Cool Blue, Synthwave, Warm) with gradient utilities.
@@ -65,3 +65,7 @@ Always create pull requests against `nathanm412/Elgato-VUMeter`, not any upstrea
 GitHub Actions (`.github/workflows/ci.yml`) runs on pushes to `main`, `develop`, `feature/**`, `claude/**` and PRs to `main`. Pipeline: lint + typecheck -> tests -> build -> package (main/tags only) -> release (version tags only).
 
 A second workflow (`.github/workflows/release-on-merge.yml`) automates releases when a PR with a `Pre-Release` or `New-Release` label is merged to `main`. `Pre-Release` creates a pre-release with a date+SHA tag; `New-Release` creates a full release using the version from `package.json`. Releases can also be created manually by pushing a `v*` tag.
+
+## Documentation & Hover Text
+
+When changing functionality, always update the corresponding hover text / tooltips in `manifest.json` (Tooltip, TriggerDescription), source file doc comments, property inspector tips, and README. Mismatched documentation confuses users and is easy to miss.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Renders a full-width stereo VU meter across the 800x100 pixel touch strip, with 
 
 Encoder interactions:
 - **Rotate** — Adjust sensitivity
-- **Push** — Toggle peak hold
+- **Push** — Toggle auto/manual sensitivity
 - **Tap** — Cycle color themes
 - **Long press** — Reset peak markers
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ A real-time stereo audio VU meter plugin for Elgato Stream Deck devices. Feature
 
 ## Display Modes
 
-### Two-Row Mode
+The keypad action supports two modes, selectable from the Property Inspector:
+
+### Two-Row Mode (default)
 
 Uses two rows of keys — top row for Left channel, bottom row for Right:
 
@@ -35,7 +37,7 @@ Uses two rows of keys — top row for Left channel, bottom row for Right:
 
 Place any number of keys per row — the meter dynamically scales its segment count to match. Each key renders a gradient bar with continuous fill, giving you far more resolution than a simple on/off display.
 
-**Single-row horizontal mode:** If all Two-Row keys are placed in one row with horizontal orientation, the meter automatically switches to mono mode, combining both channels into a single left-to-right display spanning all keys.
+**Single-row horizontal mode:** If all keys are placed in one row with horizontal orientation, the meter automatically switches to mono mode, combining both channels into a single left-to-right display spanning all keys.
 
 ### One-Row Mode
 
@@ -64,11 +66,14 @@ Open the property inspector for any VU Meter action to configure:
 
 | Setting | Options | Description |
 |---------|---------|-------------|
+| **Mode** | Two Row, One Row | Display layout (keypad action only) |
 | **Theme** | Classic, Cool Blue, Synthwave, Warm | Color scheme for the meter bars |
 | **Orientation** | Vertical, Horizontal | Bar fill direction (key actions only) |
+| **Display Style** | Gradient, Solid | Smooth fills or classic on/off segments |
 | **Show Peaks** | On/Off | Peak hold indicator lines |
+| **Sensitivity** | 0.50x – 2.00x slider | Auto-sensitivity tuning multiplier |
 
-You can also press any VU meter key to quickly cycle through themes.
+You can also press any VU meter key to quickly cycle through themes. Theme changes sync across all active actions.
 
 ## Color Themes
 
@@ -137,8 +142,8 @@ Then double-click the generated `com.nathanm412.vumeter.streamDeckPlugin` file.
 src/
   plugin.ts                   # Main entry point & orchestrator
   actions/
-    vumeter-two-row.ts        # Two-row display mode (dynamic key count)
-    vumeter-one-row.ts        # One-row split L/R mode (dynamic key count)
+    vumeter-two-row.ts        # Unified keypad action (two-row + one-row modes)
+    vumeter-one-row.ts        # Legacy one-row compat (hidden from action list)
     vumeter-touch.ts          # Touch strip display mode
   audio/
     audio-capture.ts          # Cross-platform audio capture
@@ -158,8 +163,7 @@ src/
 ```
 AudioCapture  --> emits 'levels' events at ~20fps
     |
-    |-- VUMeterTwoRow.updateLevels()  -> renders gradient key SVGs
-    |-- VUMeterOneRow.updateLevels()  -> renders split L/R key SVGs
+    |-- VUMeterKeypad.updateLevels()  -> renders key SVGs (two-row/one-row modes)
     '-- VUMeterTouch.updateLevels()   -> renders touch strip SVGs
 ```
 

--- a/com.nathanm412.vumeter.sdPlugin/manifest.json
+++ b/com.nathanm412.vumeter.sdPlugin/manifest.json
@@ -4,7 +4,7 @@
   "Name": "VU Meter",
   "Version": "1.0.0.0",
   "Author": "nathanm412",
-  "Description": "Real-time stereo VU meter with gradient key fills and touch display support. Designed for Stream Deck Plus with three display modes: two-row, one-row, and touch strip.",
+  "Description": "Real-time stereo VU meter with gradient key fills and touch display support. Designed for Stream Deck Plus with keypad and touch strip display modes.",
   "Category": "Audio",
   "CategoryIcon": "imgs/category-icon",
   "Icon": "imgs/plugin-icon",
@@ -30,8 +30,8 @@
   "Actions": [
     {
       "UUID": "com.nathanm412.vumeter.two-row",
-      "Name": "VU Meter (Two Row)",
-      "Tooltip": "Stereo VU meter using two rows of keys. Top row = Left channel, Bottom row = Right channel. Each key shows a gradient fill for fine-grained level display.",
+      "Name": "VU Meter (Keypad)",
+      "Tooltip": "Stereo VU meter for Stream Deck keys. Choose Two-Row mode (separate rows for L/R channels) or One-Row mode (split L/R per key) in settings.",
       "Icon": "imgs/actions/two-row",
       "Controllers": ["Keypad"],
       "States": [
@@ -48,6 +48,7 @@
       "UUID": "com.nathanm412.vumeter.one-row",
       "Name": "VU Meter (One Row)",
       "Tooltip": "Compact stereo VU meter using a single row of keys. Each key is split vertically showing Left and Right channels side by side.",
+      "VisibleInActionsList": false,
       "Icon": "imgs/actions/one-row",
       "Controllers": ["Keypad"],
       "States": [

--- a/com.nathanm412.vumeter.sdPlugin/manifest.json
+++ b/com.nathanm412.vumeter.sdPlugin/manifest.json
@@ -31,7 +31,7 @@
     {
       "UUID": "com.nathanm412.vumeter.two-row",
       "Name": "VU Meter (Two Row)",
-      "Tooltip": "Stereo VU meter using two rows of 4 keys. Top row = Left channel, Bottom row = Right channel. Each key shows a gradient fill for fine-grained level display.",
+      "Tooltip": "Stereo VU meter using two rows of keys. Top row = Left channel, Bottom row = Right channel. Each key shows a gradient fill for fine-grained level display.",
       "Icon": "imgs/actions/two-row",
       "Controllers": ["Keypad"],
       "States": [
@@ -47,7 +47,7 @@
     {
       "UUID": "com.nathanm412.vumeter.one-row",
       "Name": "VU Meter (One Row)",
-      "Tooltip": "Compact stereo VU meter using one row of 4 keys. Each key is split vertically showing Left and Right channels side by side.",
+      "Tooltip": "Compact stereo VU meter using a single row of keys. Each key is split vertically showing Left and Right channels side by side.",
       "Icon": "imgs/actions/one-row",
       "Controllers": ["Keypad"],
       "States": [
@@ -63,14 +63,14 @@
     {
       "UUID": "com.nathanm412.vumeter.touch",
       "Name": "VU Meter (Touch Display)",
-      "Tooltip": "Full-width stereo VU meter rendered on the Stream Deck Plus touch strip with classic analog needle style.",
+      "Tooltip": "Full-width stereo VU meter rendered on the Stream Deck Plus touch strip with gradient-filled segmented bars.",
       "Icon": "imgs/actions/touch",
       "Controllers": ["Encoder"],
       "Encoder": {
         "layout": "layouts/vumeter-touch.json",
         "TriggerDescription": {
           "Rotate": "Adjust sensitivity",
-          "Push": "Toggle peak hold",
+          "Push": "Toggle auto/manual sensitivity",
           "Touch": "Cycle color theme",
           "LongTouch": "Reset peaks"
         }

--- a/com.nathanm412.vumeter.sdPlugin/ui/property-inspector.html
+++ b/com.nathanm412.vumeter.sdPlugin/ui/property-inspector.html
@@ -149,12 +149,9 @@
   <div class="section">
     <div class="section-title">Audio Sensitivity</div>
     <div class="row">
-      <label for="sensitivityTuning">Auto Sensitivity</label>
-      <select id="sensitivityTuning">
-        <option value="low">Low (-15%)</option>
-        <option value="default" selected>Default</option>
-        <option value="high">High (+15%)</option>
-      </select>
+      <label for="sensitivityTuning">Sensitivity</label>
+      <input type="range" id="sensitivityTuning" min="50" max="200" step="5" value="100">
+      <span id="sensitivityValue" style="min-width: 40px; text-align: right; margin-left: 8px;">1.00x</span>
     </div>
     <div class="row">
       <label>Auto-gain adapts to your audio level. On the touch display, rotate the dial for manual control, press to toggle auto/manual.</label>
@@ -209,12 +206,26 @@
       };
     }
 
+    function parseSensitivityTuning(val) {
+      if (typeof val === "number") return val;
+      // Backward compat: convert legacy string presets to numeric
+      if (val === "low") return 85;
+      if (val === "high") return 115;
+      return 100;
+    }
+
+    function updateSensitivityLabel(val) {
+      document.getElementById("sensitivityValue").textContent = (val / 100).toFixed(2) + "x";
+    }
+
     function loadSettings() {
       document.getElementById("theme").value = settings.theme || "classic";
       document.getElementById("showPeaks").checked = settings.showPeaks !== false;
       document.getElementById("orientation").value = settings.orientation || "horizontal";
       document.getElementById("displayStyle").value = settings.displayStyle || "gradient";
-      document.getElementById("sensitivityTuning").value = settings.sensitivityTuning || "default";
+      const sensitivityVal = parseSensitivityTuning(settings.sensitivityTuning);
+      document.getElementById("sensitivityTuning").value = sensitivityVal;
+      updateSensitivityLabel(sensitivityVal);
       updateThemePreview();
 
       // Hide orientation and display style for touch action (not applicable)
@@ -228,7 +239,7 @@
       settings.showPeaks = document.getElementById("showPeaks").checked;
       settings.orientation = document.getElementById("orientation").value;
       settings.displayStyle = document.getElementById("displayStyle").value;
-      settings.sensitivityTuning = document.getElementById("sensitivityTuning").value;
+      settings.sensitivityTuning = parseInt(document.getElementById("sensitivityTuning").value, 10);
 
       if (websocket && websocket.readyState === WebSocket.OPEN) {
         websocket.send(JSON.stringify({
@@ -260,7 +271,10 @@
     document.getElementById("showPeaks").addEventListener("change", saveSettings);
     document.getElementById("orientation").addEventListener("change", saveSettings);
     document.getElementById("displayStyle").addEventListener("change", saveSettings);
-    document.getElementById("sensitivityTuning").addEventListener("change", saveSettings);
+    document.getElementById("sensitivityTuning").addEventListener("input", function () {
+      updateSensitivityLabel(parseInt(this.value, 10));
+      saveSettings();
+    });
 
     // Initialize preview
     updateThemePreview();

--- a/com.nathanm412.vumeter.sdPlugin/ui/property-inspector.html
+++ b/com.nathanm412.vumeter.sdPlugin/ui/property-inspector.html
@@ -102,6 +102,17 @@
   </style>
 </head>
 <body>
+  <div class="section" id="modeSection">
+    <div class="section-title">Display Mode</div>
+    <div class="row">
+      <label for="mode">Layout</label>
+      <select id="mode">
+        <option value="two-row">Two Row (separate L/R rows)</option>
+        <option value="one-row">One Row (split L/R per key)</option>
+      </select>
+    </div>
+  </div>
+
   <div class="section">
     <div class="section-title">Color Theme</div>
     <div class="row">
@@ -165,7 +176,8 @@
     • Touch display: tap = cycle theme, long press = reset peaks<br>
     • Place any number of keys left-to-right — the meter adapts automatically<br>
     • Use horizontal mode for a classic left-to-right level display<br>
-    • Two-row horizontal with a single row of keys = mono meter
+    • Two-row mode: horizontal with a single row of keys = mono meter<br>
+    • One-row mode: each key shows both L/R channels side by side
   </div>
 
   <script>
@@ -219,6 +231,7 @@
     }
 
     function loadSettings() {
+      document.getElementById("mode").value = settings.mode || "two-row";
       document.getElementById("theme").value = settings.theme || "classic";
       document.getElementById("showPeaks").checked = settings.showPeaks !== false;
       document.getElementById("orientation").value = settings.orientation || "horizontal";
@@ -228,13 +241,16 @@
       updateSensitivityLabel(sensitivityVal);
       updateThemePreview();
 
-      // Hide orientation and display style for touch action (not applicable)
+      // Hide controls not applicable to certain action types
       const isTouchAction = actionInfo?.action === "com.nathanm412.vumeter.touch";
+      const isLegacyOneRow = actionInfo?.action === "com.nathanm412.vumeter.one-row";
+      document.getElementById("modeSection").style.display = (isTouchAction || isLegacyOneRow) ? "none" : "";
       document.getElementById("orientationSection").style.display = isTouchAction ? "none" : "";
       document.getElementById("displayStyleSection").style.display = isTouchAction ? "none" : "";
     }
 
     function saveSettings() {
+      settings.mode = document.getElementById("mode").value;
       settings.theme = document.getElementById("theme").value;
       settings.showPeaks = document.getElementById("showPeaks").checked;
       settings.orientation = document.getElementById("orientation").value;
@@ -268,6 +284,7 @@
       saveSettings();
     });
 
+    document.getElementById("mode").addEventListener("change", saveSettings);
     document.getElementById("showPeaks").addEventListener("change", saveSettings);
     document.getElementById("orientation").addEventListener("change", saveSettings);
     document.getElementById("displayStyle").addEventListener("change", saveSettings);

--- a/src/actions/vumeter-one-row.ts
+++ b/src/actions/vumeter-one-row.ts
@@ -205,4 +205,19 @@ export class VUMeterOneRow extends SingletonAction<OneRowSettings> {
   getContextCount(): number {
     return this.contexts.size;
   }
+
+  async setTheme(theme: string): Promise<void> {
+    for (const [id, ctx] of this.contexts) {
+      ctx.settings.theme = theme;
+      try {
+        const action = streamDeck.actions.find((a) => a.id === id);
+        if (action) {
+          await action.setSettings(ctx.settings);
+        }
+      } catch {
+        // Action may have been removed
+      }
+    }
+    this.lastImages.clear();
+  }
 }

--- a/src/actions/vumeter-one-row.ts
+++ b/src/actions/vumeter-one-row.ts
@@ -31,7 +31,7 @@ interface OneRowSettings {
   showPeaks: boolean;
   orientation: "vertical" | "horizontal";
   displayStyle: DisplayStyle;
-  sensitivityTuning: string;
+  sensitivityTuning: string | number;
   [key: string]: JsonValue;
 }
 
@@ -40,7 +40,7 @@ const DEFAULT_SETTINGS: OneRowSettings = {
   showPeaks: true,
   orientation: "horizontal",
   displayStyle: "gradient",
-  sensitivityTuning: "default",
+  sensitivityTuning: 100,
 };
 
 interface ActionContext {

--- a/src/actions/vumeter-touch.ts
+++ b/src/actions/vumeter-touch.ts
@@ -7,7 +7,7 @@
  *
  * Encoder interactions:
  *   - Rotate: Adjust sensitivity
- *   - Push: Toggle peak hold
+ *   - Push: Toggle auto/manual sensitivity
  *   - Touch: Cycle color theme
  *   - Long Touch: Reset peaks
  */

--- a/src/actions/vumeter-touch.ts
+++ b/src/actions/vumeter-touch.ts
@@ -164,5 +164,20 @@ export class VUMeterTouch extends SingletonAction<TouchSettings> {
 	getContextCount(): number {
 		return this.contexts.size;
 	}
+
+	async setTheme(theme: string): Promise<void> {
+		for (const [id, ctx] of this.contexts) {
+			ctx.settings.theme = theme;
+			try {
+				const action = streamDeck.actions.find((a) => a.id === id);
+				if (action) {
+					await action.setSettings(ctx.settings);
+				}
+			} catch {
+				// Action may have been removed
+			}
+		}
+		this.lastImages.clear();
+	}
 }
 

--- a/src/actions/vumeter-touch.ts
+++ b/src/actions/vumeter-touch.ts
@@ -32,7 +32,7 @@ interface TouchSettings {
 	theme: string;
 	showPeaks: boolean;
 	sensitivity: number;
-	sensitivityTuning: string;
+	sensitivityTuning: string | number;
 	[key: string]: JsonValue;
 }
 
@@ -40,7 +40,7 @@ const DEFAULT_SETTINGS: TouchSettings = {
 	theme: "classic",
 	showPeaks: true,
 	sensitivity: 1.0,
-	sensitivityTuning: "default",
+	sensitivityTuning: 100,
 };
 
 interface EncoderContext {

--- a/src/actions/vumeter-two-row.ts
+++ b/src/actions/vumeter-two-row.ts
@@ -1,15 +1,19 @@
 /**
- * Two-Row VU Meter Action
+ * Keypad VU Meter Action (consolidated Two-Row + One-Row)
  *
- * Uses keys arranged in up to 2 rows on any Stream Deck model.
- * Top row = Left channel, Bottom row = Right channel.
+ * Supports two display modes selectable via the Property Inspector:
+ *
+ * Two-Row mode:
+ *   Uses keys in up to 2 rows. Top row = Left channel, Bottom row = Right.
+ *   When all keys are in a single row with horizontal orientation,
+ *   automatically switches to mono mode spanning the full width.
+ *
+ * One-Row mode:
+ *   Each key is split: left half = L channel, right half = R channel
+ *   (vertical) or top = L, bottom = R (horizontal).
  *
  * Dynamically detects how many keys the user has placed and adapts
- * the segment count accordingly. Supports both vertical (bottom-to-top)
- * and horizontal (left-to-right) bar orientations.
- *
- * When all keys are in a single row with horizontal orientation,
- * automatically switches to mono mode spanning the full width.
+ * the segment count accordingly.
  */
 
 import streamDeck, {
@@ -20,13 +24,21 @@ import streamDeck, {
 	WillAppearEvent,
 	WillDisappearEvent,
 } from "@elgato/streamdeck";
-import {renderKeyBar, renderHorizontalKeyBar, renderSolidKeyBar} from "../rendering/key-renderer";
+import {
+	renderKeyBar,
+	renderHorizontalKeyBar,
+	renderSolidKeyBar,
+	renderSplitKeyBar,
+	renderHorizontalSplitKeyBar,
+	renderSolidSplitKeyBar,
+} from "../rendering/key-renderer";
 import type {DisplayStyle} from "../rendering/key-renderer";
 import {AudioLevels} from "../audio/audio-capture";
 import {THEMES, THEME_ORDER} from "../utils/color";
 import type {JsonValue} from "@elgato/utils";
 
-interface TwoRowSettings {
+interface KeypadSettings {
+	mode: "one-row" | "two-row";
 	theme: string;
 	showPeaks: boolean;
 	peakHold: boolean;
@@ -36,7 +48,8 @@ interface TwoRowSettings {
 	[key: string]: JsonValue;
 }
 
-const DEFAULT_SETTINGS: TwoRowSettings = {
+const DEFAULT_SETTINGS: KeypadSettings = {
+	mode: "two-row",
 	theme: "classic",
 	showPeaks: true,
 	peakHold: true,
@@ -47,24 +60,31 @@ const DEFAULT_SETTINGS: TwoRowSettings = {
 
 interface ActionContext {
 	context: string;
-	row: number;    // 0 = top (left), 1 = bottom (right)
+	row: number;
 	column: number;
-	settings: TwoRowSettings;
+	settings: KeypadSettings;
 }
 
 @action({ UUID: "com.nathanm412.vumeter.two-row" })
-export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
+export class VUMeterKeypad extends SingletonAction<KeypadSettings> {
 	private contexts: Map<string, ActionContext> = new Map();
 	private lastImages: Map<string, string> = new Map();
-	private onSettingsChanged: ((settings: TwoRowSettings) => void) | null = null;
+	private onSettingsChanged: ((settings: KeypadSettings) => void) | null = null;
 
-	setOnSettingsChanged(cb: (settings: TwoRowSettings) => void): void {
+	setOnSettingsChanged(cb: (settings: KeypadSettings) => void): void {
 		this.onSettingsChanged = cb;
 	}
 	private totalSegments = 1;
 	private minColumn = 0;
 	private minRow = 0;
 	private isSingleRowMode = false;
+
+	private getMode(): "one-row" | "two-row" {
+		// All contexts share the same mode; read from the first one
+		const first = this.contexts.values().next();
+		if (first.done) return "two-row";
+		return first.value.settings.mode || "two-row";
+	}
 
 	private computeSegmentInfo(): void {
 		if (this.contexts.size === 0) {
@@ -86,7 +106,13 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 		this.minColumn = Math.min(...columns);
 		this.minRow = Math.min(...rows);
 		this.totalSegments = Math.max(...columns) - this.minColumn + 1;
-		this.isSingleRowMode = rows.size === 1;
+
+		// Only track row info for two-row mode
+		if (this.getMode() === "two-row") {
+			this.isSingleRowMode = rows.size === 1;
+		} else {
+			this.isSingleRowMode = false;
+		}
 
 		// Force full re-render when segment count changes
 		if (oldSegments !== this.totalSegments) {
@@ -94,7 +120,7 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 		}
 	}
 
-	override async onWillAppear(ev: WillAppearEvent<TwoRowSettings>): Promise<void> {
+	override async onWillAppear(ev: WillAppearEvent<KeypadSettings>): Promise<void> {
 		const settings = {...DEFAULT_SETTINGS, ...ev.payload.settings};
 		const coords = (ev.payload as Record<string, unknown>).coordinates as { row: number; column: number } | undefined;
 		if (!coords) return;
@@ -111,12 +137,19 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 		// Set initial dark state
 		const theme = THEMES[settings.theme] || THEMES.classic;
 		const segIdx = coords.column - this.minColumn;
-		const renderFn = settings.orientation === "horizontal" ? renderHorizontalKeyBar : renderKeyBar;
-		const img = renderFn(0, segIdx, this.totalSegments, theme, -1, false);
+
+		let img: string;
+		if (settings.mode === "one-row") {
+			const renderFn = settings.orientation === "horizontal" ? renderHorizontalSplitKeyBar : renderSplitKeyBar;
+			img = renderFn(0, 0, segIdx, this.totalSegments, theme);
+		} else {
+			const renderFn = settings.orientation === "horizontal" ? renderHorizontalKeyBar : renderKeyBar;
+			img = renderFn(0, segIdx, this.totalSegments, theme, -1, false);
+		}
 		await ev.action.setImage(img);
 	}
 
-	override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<TwoRowSettings>): Promise<void> {
+	override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<KeypadSettings>): Promise<void> {
 		const ctx = this.contexts.get(ev.action.id);
 		if (!ctx) return;
 		const newSettings = { ...DEFAULT_SETTINGS, ...ev.payload.settings };
@@ -136,6 +169,9 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 			}
 		}
 
+		// Recompute segments (mode change may affect row handling)
+		this.computeSegmentInfo();
+
 		// Force full re-render
 		this.lastImages.clear();
 
@@ -143,13 +179,13 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 		this.onSettingsChanged?.(newSettings);
 	}
 
-	override async onWillDisappear(ev: WillDisappearEvent<TwoRowSettings>): Promise<void> {
+	override async onWillDisappear(ev: WillDisappearEvent<KeypadSettings>): Promise<void> {
 		this.contexts.delete(ev.action.id);
 		this.lastImages.delete(ev.action.id);
 		this.computeSegmentInfo();
 	}
 
-	override async onKeyDown(ev: KeyDownEvent<TwoRowSettings>): Promise<void> {
+	override async onKeyDown(ev: KeyDownEvent<KeypadSettings>): Promise<void> {
 		// Cycle through themes on key press
 		const ctx = this.contexts.get(ev.action.id);
 		if (!ctx) return;
@@ -163,9 +199,18 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 
 	/**
 	 * Called by the plugin manager with new audio levels.
-	 * Calculates per-key fill levels and updates the display.
+	 * Dispatches to mode-specific rendering.
 	 */
 	async updateLevels(levels: AudioLevels): Promise<void> {
+		const mode = this.getMode();
+		if (mode === "one-row") {
+			await this.updateLevelsOneRow(levels);
+		} else {
+			await this.updateLevelsTwoRow(levels);
+		}
+	}
+
+	private async updateLevelsTwoRow(levels: AudioLevels): Promise<void> {
 		for (const [id, ctx] of this.contexts) {
 			const theme = THEMES[ctx.settings.theme] || THEMES.classic;
 			const segIdx = ctx.column - this.minColumn;
@@ -217,6 +262,62 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 			}
 
 			// Only update if the image actually changed (reduces USB traffic)
+			const lastImg = this.lastImages.get(id);
+			if (img !== lastImg) {
+				this.lastImages.set(id, img);
+				try {
+					const action = streamDeck.actions.find((a) => a.id === id);
+					if (action) {
+						await action.setImage(img);
+					}
+				} catch {
+					// Action may have been removed
+				}
+			}
+		}
+	}
+
+	private async updateLevelsOneRow(levels: AudioLevels): Promise<void> {
+		const calcFill = (level: number, start: number, end: number) => {
+			if (level >= end) return 1.0;
+			if (level > start) return (level - start) / (end - start);
+			return 0;
+		};
+
+		const calcPeak = (peak: number, start: number, end: number) => {
+			if (peak >= start && peak < end) {
+				return (peak - start) / (end - start);
+			}
+			return -1;
+		};
+
+		for (const [id, ctx] of this.contexts) {
+			const theme = THEMES[ctx.settings.theme] || THEMES.classic;
+			const segIdx = ctx.column - this.minColumn;
+			const isHorizontal = ctx.settings.orientation === "horizontal";
+			const isSolid = ctx.settings.displayStyle === "solid";
+
+			const segStart = segIdx / this.totalSegments;
+			const segEnd = (segIdx + 1) / this.totalSegments;
+
+			let img: string;
+
+			if (isSolid) {
+				const leftLit = levels.left >= segEnd || levels.left > segStart;
+				const rightLit = levels.right >= segEnd || levels.right > segStart;
+				const leftIsPeak = ctx.settings.showPeaks && levels.peakLeft >= segStart && levels.peakLeft < segEnd;
+				const rightIsPeak = ctx.settings.showPeaks && levels.peakRight >= segStart && levels.peakRight < segEnd;
+				img = renderSolidSplitKeyBar(leftLit, rightLit, segIdx, this.totalSegments, theme, !leftLit && leftIsPeak, !rightLit && rightIsPeak);
+			} else {
+				const leftFill = calcFill(levels.left, segStart, segEnd);
+				const rightFill = calcFill(levels.right, segStart, segEnd);
+				const peakL = ctx.settings.showPeaks ? calcPeak(levels.peakLeft, segStart, segEnd) : -1;
+				const peakR = ctx.settings.showPeaks ? calcPeak(levels.peakRight, segStart, segEnd) : -1;
+
+				const renderFn = isHorizontal ? renderHorizontalSplitKeyBar : renderSplitKeyBar;
+				img = renderFn(leftFill, rightFill, segIdx, this.totalSegments, theme, peakL, peakR);
+			}
+
 			const lastImg = this.lastImages.get(id);
 			if (img !== lastImg) {
 				this.lastImages.set(id, img);

--- a/src/actions/vumeter-two-row.ts
+++ b/src/actions/vumeter-two-row.ts
@@ -32,7 +32,7 @@ interface TwoRowSettings {
 	peakHold: boolean;
 	orientation: "vertical" | "horizontal";
 	displayStyle: DisplayStyle;
-	sensitivityTuning: string;
+	sensitivityTuning: string | number;
 	[key: string]: JsonValue;
 }
 
@@ -42,7 +42,7 @@ const DEFAULT_SETTINGS: TwoRowSettings = {
 	peakHold: true,
 	orientation: "horizontal",
 	displayStyle: "gradient",
-	sensitivityTuning: "default",
+	sensitivityTuning: 100,
 };
 
 interface ActionContext {

--- a/src/actions/vumeter-two-row.ts
+++ b/src/actions/vumeter-two-row.ts
@@ -235,4 +235,19 @@ export class VUMeterTwoRow extends SingletonAction<TwoRowSettings> {
 	getContextCount(): number {
 		return this.contexts.size;
 	}
+
+	async setTheme(theme: string): Promise<void> {
+		for (const [id, ctx] of this.contexts) {
+			ctx.settings.theme = theme;
+			try {
+				const action = streamDeck.actions.find((a) => a.id === id);
+				if (action) {
+					await action.setSettings(ctx.settings);
+				}
+			} catch {
+				// Action may have been removed
+			}
+		}
+		this.lastImages.clear();
+	}
 }

--- a/src/audio/audio-capture.ts
+++ b/src/audio/audio-capture.ts
@@ -594,9 +594,14 @@ export class AudioCapture extends EventEmitter {
 
   /**
    * Set the auto-sensitivity tuning level.
-   * "low" = 0.85x (less sensitive), "default" = 1.0x, "high" = 1.15x (more sensitive)
+   * Accepts a numeric value (percentage, e.g. 100 = 1.0x) or legacy
+   * string presets: "low" = 0.85x, "default" = 1.0x, "high" = 1.15x.
    */
-  setSensitivityTuning(tuning: string): void {
+  setSensitivityTuning(tuning: string | number): void {
+    if (typeof tuning === "number") {
+      this.sensitivityTuning = tuning / 100;
+      return;
+    }
     switch (tuning) {
       case "low": this.sensitivityTuning = 0.85; break;
       case "high": this.sensitivityTuning = 1.15; break;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,17 +34,38 @@ function applySensitivityTuning(settings: { sensitivityTuning?: string }): void 
   }
 }
 
+// Cross-action theme sync
+let currentTheme = "classic";
+
+function syncTheme(newTheme: string, source: "two-row" | "one-row" | "touch"): void {
+  if (newTheme === currentTheme) return;
+  currentTheme = newTheme;
+
+  if (source !== "two-row") twoRowAction.setTheme(newTheme);
+  if (source !== "one-row") oneRowAction.setTheme(newTheme);
+  if (source !== "touch") touchAction.setTheme(newTheme);
+}
+
 // Wire up touch encoder callbacks
 touchAction.setCallbacks(
   (delta) => audioCapture.adjustSensitivity(delta),
   () => audioCapture.resetPeaks(),
   () => audioCapture.toggleSensitivityMode(),
-  (settings) => applySensitivityTuning(settings),
+  (settings) => {
+    applySensitivityTuning(settings);
+    if (settings.theme) syncTheme(settings.theme, "touch");
+  },
 );
 
 // Wire up key action settings callbacks
-twoRowAction.setOnSettingsChanged((settings) => applySensitivityTuning(settings));
-oneRowAction.setOnSettingsChanged((settings) => applySensitivityTuning(settings));
+twoRowAction.setOnSettingsChanged((settings) => {
+  applySensitivityTuning(settings);
+  if (settings.theme) syncTheme(settings.theme, "two-row");
+});
+oneRowAction.setOnSettingsChanged((settings) => {
+  applySensitivityTuning(settings);
+  if (settings.theme) syncTheme(settings.theme, "one-row");
+});
 
 // Rate limiter for display updates
 let lastUpdateTime = 0;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,25 +2,25 @@
  * VU Meter Plugin — Main Entry Point
  *
  * Orchestrates audio capture and distributes level data to all active
- * display actions (two-row, one-row, and touch display).
+ * display actions (keypad and touch display).
  *
  * Architecture:
  *   AudioCapture  ──> emits 'levels' events at ~20fps
  *       │
- *       ├──> VUMeterTwoRow.updateLevels()  (key rendering)
- *       ├──> VUMeterOneRow.updateLevels()  (key rendering)
+ *       ├──> VUMeterKeypad.updateLevels()  (key rendering, two-row/one-row modes)
+ *       ├──> VUMeterOneRow.updateLevels()  (legacy compat, hidden from action list)
  *       └──> VUMeterTouch.updateLevels()   (touch strip rendering)
  */
 
 import streamDeck from "@elgato/streamdeck";
-import { VUMeterTwoRow } from "./actions/vumeter-two-row";
+import { VUMeterKeypad } from "./actions/vumeter-two-row";
 import { VUMeterOneRow } from "./actions/vumeter-one-row";
 import { VUMeterTouch } from "./actions/vumeter-touch";
 import { AudioCapture, AudioLevels } from "./audio/audio-capture";
 import { UPDATE_INTERVAL_MS } from "./utils/constants";
 
 // Create action singletons
-const twoRowAction = new VUMeterTwoRow();
+const keypadAction = new VUMeterKeypad();
 const oneRowAction = new VUMeterOneRow();
 const touchAction = new VUMeterTouch();
 
@@ -41,7 +41,7 @@ function syncTheme(newTheme: string, source: "two-row" | "one-row" | "touch"): v
   if (newTheme === currentTheme) return;
   currentTheme = newTheme;
 
-  if (source !== "two-row") twoRowAction.setTheme(newTheme);
+  if (source !== "two-row") keypadAction.setTheme(newTheme);
   if (source !== "one-row") oneRowAction.setTheme(newTheme);
   if (source !== "touch") touchAction.setTheme(newTheme);
 }
@@ -58,7 +58,7 @@ touchAction.setCallbacks(
 );
 
 // Wire up key action settings callbacks
-twoRowAction.setOnSettingsChanged((settings) => {
+keypadAction.setOnSettingsChanged((settings) => {
   applySensitivityTuning(settings);
   if (settings.theme) syncTheme(settings.theme, "two-row");
 });
@@ -92,8 +92,8 @@ function scheduleUpdate(levels: AudioLevels): void {
     // Distribute to all active actions concurrently
     const updates: Promise<void>[] = [];
 
-    if (twoRowAction.getContextCount() > 0) {
-      updates.push(twoRowAction.updateLevels(lvl));
+    if (keypadAction.getContextCount() > 0) {
+      updates.push(keypadAction.updateLevels(lvl));
     }
     if (oneRowAction.getContextCount() > 0) {
       updates.push(oneRowAction.updateLevels(lvl));
@@ -115,7 +115,7 @@ audioCapture.on("levels", (levels: AudioLevels) => {
 audioCapture.start();
 
 // Register actions and connect
-streamDeck.actions.registerAction(twoRowAction);
+streamDeck.actions.registerAction(keypadAction);
 streamDeck.actions.registerAction(oneRowAction);
 streamDeck.actions.registerAction(touchAction);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -28,8 +28,8 @@ const touchAction = new VUMeterTouch();
 const audioCapture = new AudioCapture();
 
 // Handle sensitivity tuning from any action's settings
-function applySensitivityTuning(settings: { sensitivityTuning?: string }): void {
-  if (settings.sensitivityTuning) {
+function applySensitivityTuning(settings: { sensitivityTuning?: string | number }): void {
+  if (settings.sensitivityTuning !== undefined) {
     audioCapture.setSensitivityTuning(settings.sensitivityTuning);
   }
 }


### PR DESCRIPTION
## Summary
- **Fix hover text**: Correct 4 inaccurate tooltips/trigger descriptions in manifest, README, and source comments
- **Theme sync**: Theme cycling now propagates across all action types (keypad + touch) via plugin orchestrator mediator
- **Sensitivity slider**: Replace 3-preset dropdown with continuous range slider (0.50x–2.00x), backward compatible with legacy string values
- **Action consolidation**: Merge One-Row and Two-Row into a single "VU Meter (Keypad)" action with mode dropdown. Legacy one-row action hidden via `VisibleInActionsList: false` for backward compatibility
- **Documentation**: Update README and CLAUDE.md for all changes, add instruction to keep hover text in sync

Fixes #40

## Test plan
- [x] Lint, typecheck, and tests pass on all commits
- [x] Full build succeeds
- [x] Verify mode dropdown appears for keypad action, hidden for touch/legacy
- [x] Test Two-Row and One-Row mode rendering
- [ ] Test theme cycling syncs across keypad and touch actions
- [ ] Test sensitivity slider saves and applies correctly
- [ ] Verify existing two-row profiles work unchanged (same UUID)
- [ ] Verify existing one-row profiles still function (hidden action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)