### PR TITLE
Sync manifest.json version and description from package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
         run: |
           test -f com.nathanm412.vumeter.sdPlugin/bin/plugin.js
           test -f com.nathanm412.vumeter.sdPlugin/manifest.json
+      - name: Verify manifest.json is in sync
+        run: |
+          git diff --exit-code com.nathanm412.vumeter.sdPlugin/manifest.json || {
+            echo "::error::manifest.json is out of sync with package.json. Run 'npm run build' locally and commit the changes."
+            exit 1
+          }
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,5 @@ A second workflow (`.github/workflows/release-on-merge.yml`) automates releases 
 ## Documentation & Hover Text
 
 When changing functionality, always update the corresponding hover text / tooltips in `manifest.json` (Tooltip, TriggerDescription), source file doc comments, property inspector tips, and README. Mismatched documentation confuses users and is easy to miss.
+
+When changing the plugin description in README.md, also update the `description` field in `package.json`. The build system automatically syncs this to `manifest.json`. Run `npm run build` and commit the updated manifest.

--- a/com.nathanm412.vumeter.sdPlugin/manifest.json
+++ b/com.nathanm412.vumeter.sdPlugin/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
   "UUID": "com.nathanm412.vumeter",
   "Name": "VU Meter",
-  "Version": "1.0.0.0",
+  "Version": "1.2.0.0",
   "Author": "nathanm412",
   "Description": "Real-time stereo VU meter with gradient key fills and touch display support. Designed for Stream Deck Plus with keypad and touch strip display modes.",
   "Category": "Audio",
@@ -33,7 +33,9 @@
       "Name": "VU Meter (Keypad)",
       "Tooltip": "Stereo VU meter for Stream Deck keys. Choose Two-Row mode (separate rows for L/R channels) or One-Row mode (split L/R per key) in settings.",
       "Icon": "imgs/actions/two-row",
-      "Controllers": ["Keypad"],
+      "Controllers": [
+        "Keypad"
+      ],
       "States": [
         {
           "Image": "imgs/actions/two-row-key",
@@ -50,7 +52,9 @@
       "Tooltip": "Compact stereo VU meter using a single row of keys. Each key is split vertically showing Left and Right channels side by side.",
       "VisibleInActionsList": false,
       "Icon": "imgs/actions/one-row",
-      "Controllers": ["Keypad"],
+      "Controllers": [
+        "Keypad"
+      ],
       "States": [
         {
           "Image": "imgs/actions/one-row-key",
@@ -66,7 +70,9 @@
       "Name": "VU Meter (Touch Display)",
       "Tooltip": "Full-width stereo VU meter rendered on the Stream Deck Plus touch strip with gradient-filled segmented bars.",
       "Icon": "imgs/actions/touch",
-      "Controllers": ["Encoder"],
+      "Controllers": [
+        "Encoder"
+      ],
       "Encoder": {
         "layout": "layouts/vumeter-touch.json",
         "TriggerDescription": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "com.nathanm412.vumeter",
   "version": "1.2.0",
-  "description": "Real-time stereo VU meter for Elgato Stream Deck Plus with gradient key fills and touch display support",
+  "description": "Real-time stereo VU meter with gradient key fills and touch display support. Designed for Stream Deck Plus with keypad and touch strip display modes.",
   "main": "com.nathanm412.vumeter.sdPlugin/bin/plugin.js",
   "scripts": {
-    "build": "rollup -c && node scripts/copy-assets.js",
+    "build": "node scripts/sync-manifest.js && rollup -c && node scripts/copy-assets.js",
+    "sync-manifest": "node scripts/sync-manifest.js",
     "watch": "tsc --watch",
     "pack": "npm run build && node scripts/pack.js",
     "lint": "eslint src/",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -115,18 +115,30 @@ async function main() {
   console.log("\nRunning tests...");
   runVisible("npm test");
 
+  // Bump version in package.json/package-lock.json (without committing)
+  console.log(`\nBumping version to ${newVersion}...`);
+  runVisible(`npm version ${npmVersionArg} --no-git-tag-version`);
+
+  // Sync manifest.json with the new version
+  console.log("\nSyncing manifest.json...");
+  runVisible("node scripts/sync-manifest.js");
+
+  // Build with the new version
   console.log("\nBuilding...");
   runVisible("npm run build");
 
-  // Bump version, commit, and tag
-  console.log(`\nBumping version to ${newVersion}...`);
-  runVisible(`npm version ${npmVersionArg} -m "Release %s"`);
+  // Commit, tag, and push
+  const versionTag = newVersion.startsWith("v") ? newVersion : `v${newVersion}`;
+  console.log(`\nCommitting release ${versionTag}...`);
+  runVisible("git add package.json package-lock.json com.nathanm412.vumeter.sdPlugin/manifest.json");
+  runVisible(`git commit -m "Release ${versionTag}"`);
+  runVisible(`git tag ${versionTag}`);
 
   // Push commit and tag
   console.log("\nPushing to origin...");
   runVisible("git push origin main --follow-tags");
 
-  console.log(`\nDone! Release ${newVersion} has been pushed.`);
+  console.log(`\nDone! Release ${versionTag} has been pushed.`);
   console.log("CI will build, package, and create the GitHub release automatically.");
   console.log("Monitor at: https://github.com/nathanm412/Elgato-VUMeter/actions");
 }

--- a/scripts/sync-manifest.js
+++ b/scripts/sync-manifest.js
@@ -1,0 +1,57 @@
+/**
+ * Syncs version and description from package.json into manifest.json.
+ *
+ * - Converts semver (X.Y.Z or X.Y.Z-N) to 4-part version (X.Y.Z.0)
+ * - Copies description verbatim
+ * - Only writes if changes are needed
+ */
+const fs = require("fs");
+const path = require("path");
+
+const MANIFEST_PATH = path.join(
+  __dirname,
+  "..",
+  "com.nathanm412.vumeter.sdPlugin",
+  "manifest.json",
+);
+
+const pkg = require("../package.json");
+
+if (!fs.existsSync(MANIFEST_PATH)) {
+  console.error(`Error: manifest.json not found at ${MANIFEST_PATH}`);
+  process.exit(1);
+}
+
+const manifestRaw = fs.readFileSync(MANIFEST_PATH, "utf-8");
+const manifest = JSON.parse(manifestRaw);
+
+// Convert semver to 4-part version: "1.2.0" -> "1.2.0.0", "1.2.0-3" -> "1.2.0.0"
+const coreParts = pkg.version.split("-")[0].split(".");
+const fourPartVersion = [
+  coreParts[0] || "0",
+  coreParts[1] || "0",
+  coreParts[2] || "0",
+  "0",
+].join(".");
+
+const changes = [];
+
+if (manifest.Version !== fourPartVersion) {
+  changes.push(`Version: "${manifest.Version}" -> "${fourPartVersion}"`);
+  manifest.Version = fourPartVersion;
+}
+
+if (manifest.Description !== pkg.description) {
+  changes.push(`Description updated to match package.json`);
+  manifest.Description = pkg.description;
+}
+
+if (changes.length > 0) {
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n");
+  console.log("manifest.json synced with package.json:");
+  for (const change of changes) {
+    console.log(`  - ${change}`);
+  }
+} else {
+  console.log("manifest.json is already in sync with package.json");
+}


### PR DESCRIPTION
Add scripts/sync-manifest.js that converts semver to 4-part version
and copies description from package.json into manifest.json. Integrated
into the build pipeline so every build keeps them in sync. Updated
release.js to include manifest.json in release commits, and added a CI
check to catch drift. Fixes #53.

https://claude.ai/code/session_01UZZwF2XUJuuwn5mkxdPsQz