### PR TITLE
Block archiver major upgrades in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,16 @@
   },
   "packageRules": [
     {
+      "description": "Block archiver major upgrades: v8 dropped the archiver('zip', opts) factory API that scripts/pack.js depends on, which breaks release packaging. Remove this rule only after pack.js is migrated to the new API or archiver is replaced (see issue #112).",
+      "matchPackageNames": [
+        "archiver"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "matchDepTypes": [
         "devDependencies"
       ],


### PR DESCRIPTION
Adds a Renovate `packageRule` that disables **major** updates for `archiver`.

## Why

archiver v8 removed the `archiver("zip", opts)` factory API that `scripts/pack.js` relies on, which broke the release packaging step (`TypeError: archiver is not a function`). That was fixed in #109 by pinning archiver to `^7.0.1`, but Renovate keeps re-proposing the v8 bump (#111) — merging it would re-break the release.

This rule stops Renovate from raising archiver major-version PRs until `pack.js` is migrated to the v8 API or archiver is replaced (e.g. with the `@elgato/cli` `streamdeck pack` command). Tracked in #112.

Minor/patch archiver updates are unaffected.

## Removal

Delete this `packageRule` once #112's archiver migrate-or-replace work lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A166kR5W6f32ueZDdJY2Xc)_