### PR TITLE
Align plugin runtime to Node 24 (Stream Deck 7.1+)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,22 @@ AudioCapture  ──> emits 'levels' events at ~20fps
 
 Rollup bundles `src/plugin.ts` into a single CJS file at `com.nathanm412.vumeter.sdPlugin/bin/plugin.js`. The `scripts/copy-assets.js` post-build step copies helper scripts into the plugin directory.
 
+## Packaging
+
+`npm run pack` builds, then runs the official Elgato CLI's `streamdeck pack` (`@elgato/cli`) — there is no hand-rolled zip script. Notes:
+
+- **It validates the manifest**; validation *errors* abort packing (warnings don't). The top-level plugin `Icon` **must be a `.png`** (with `@2x`); action/`CategoryIcon` icons may be SVG. PNG icons are committed alongside the SVGs in `imgs/`.
+- Excludes are driven by `com.nathanm412.vumeter.sdPlugin/.sdignore` (maps, `.d.ts`, test files, etc.) — edit that, not the pack command, to change what ships.
+- `streamdeck pack` **re-serializes `manifest.json` without a trailing newline** as a side effect. To keep `build`/`pack` from dirtying the tree, `sync-manifest.js` also writes the manifest without a trailing newline — don't re-add one.
+
+## manifest.json conventions
+
+`com.nathanm412.vumeter.sdPlugin/manifest.json` is **partly generated**: `scripts/sync-manifest.js` (run as the first build step) syncs only `Version` (as `X.Y.Z.0`) and `Description` from `package.json`; everything else is hand-edited. The CI build job enforces manifest-in-sync, and a separate `validate-manifest.yml` workflow checks JSON validity, required fields, unique action UUIDs, and referenced files.
+
+## Node runtime / `@types/node` alignment
+
+The plugin runs under the Node version declared in `manifest.json` `Nodejs.Version` — **not** the latest available. Keep `@types/node`, the `@tsconfig/node*` base, and CI's `node-version` matched to it. Stream Deck only ships **Node 20 or 24** runtimes (per `@elgato/schemas`); there is no Node 26 runtime. Node `24` requires `Software.MinimumVersion` ≥ **7.1** (lower minimums force Node 20). A Renovate rule blocks `@types/node` major bumps so it tracks the runtime — bump `@types/node` and `manifest.Nodejs.Version` together. `tsconfig.json` pins `"types": ["node", "jest"]` (TS 6 no longer auto-resolves the Jest ambient globals for the typechecked `*.test.ts` files otherwise). A full dependency inventory lives in `docs/dependency-review.md`.
+
 ## Testing
 
 Jest with `ts-jest` preset. Tests live alongside source files (`*.test.ts`). Current test coverage: rendering logic (`key-renderer.test.ts`) and color utilities (`color.test.ts`). Coverage excludes `plugin.ts` and `.d.ts` files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a TypeScript Stream Deck plugin that renders a real-time stereo audio VU meter on Elgato Stream Deck keys and touch displays. It uses the Elgato Stream Deck SDK v2 (`@elgato/streamdeck`) and targets Node.js 20.
+This is a TypeScript Stream Deck plugin that renders a real-time stereo audio VU meter on Elgato Stream Deck keys and touch displays. It uses the Elgato Stream Deck SDK v2 (`@elgato/streamdeck`) and targets Node.js 24 (requires the Stream Deck app 7.1+).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ The plugin works on any Stream Deck model with LCD keys:
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 24+
 - npm 9+
-- Stream Deck app 6.6+ (for testing)
+- Stream Deck app 7.1+ (for testing)
 - Elgato Stream Deck hardware (for full testing)
 
 ### Commands

--- a/com.nathanm412.vumeter.sdPlugin/manifest.json
+++ b/com.nathanm412.vumeter.sdPlugin/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
   "UUID": "com.nathanm412.vumeter",
   "Name": "VU Meter",
-  "Version": "1.2.2.0",
+  "Version": "1.3.0.0",
   "Author": "nathanm412",
   "Description": "Real-time stereo VU meter with gradient key fills and touch display support. Designed for Stream Deck Plus with keypad and touch strip display modes.",
   "Category": "Audio",
@@ -11,7 +11,7 @@
   "CodePath": "bin/plugin.js",
   "SDKVersion": 2,
   "Software": {
-    "MinimumVersion": "6.6"
+    "MinimumVersion": "7.1"
   },
   "OS": [
     {
@@ -24,7 +24,7 @@
     }
   ],
   "Nodejs": {
-    "Version": "20",
+    "Version": "24",
     "Debug": "enabled"
   },
   "Actions": [

--- a/docs/dependency-review.md
+++ b/docs/dependency-review.md
@@ -18,7 +18,7 @@ state at review time; "latest" is the published version on npm at that point.
 | `typescript` | `6.0.3` | 6.0.3 | 0 | **Upgraded 5.9.3 → 6.0.3 in this PR** (closes #33). See notes below. |
 | `eslint` | `10.6.0` | 10.6.0 | 0 | **Bumped 10.5.0 → 10.6.0** (safe minor). |
 | `archiver` | — | 8.0.0 | n/a | **Removed.** Replaced by `@elgato/cli` packaging (see below); was the root cause of the failed first v1.2.1 release (#109). |
-| `@types/node` | `24.13.2` | 26.0.1 | 2 | **Hold at 24.x intentionally.** Kept aligned with the Node 24 tsconfig base (`@tsconfig/node24`) and the Node 20–24 runtime target; jumping to Node 26 type defs would expose APIs not guaranteed at runtime. Revisit when the runtime/tsconfig base moves up. |
+| `@types/node` | `24.13.2` | 26.0.1 | 2 | **Hold at 24.x intentionally** — now correctly aligned with the Node 24 *runtime*. The plugin's runtime is whatever `manifest.json` `Nodejs.Version` declares (now `"24"`), not the latest npm release. Stream Deck only ships Node 20 or Node 24 runtimes (`@elgato/schemas` enum is `["20","24"]`); there is **no Node 26 runtime**, so `@types/node@26` would type-check against APIs that don't exist at runtime. Keep `@types/node`, `@tsconfig/node24`, and CI's `node-version: '24'` matched to the manifest's Node version. |
 | `@elgato/cli` | `1.7.4` | 1.7.4 | 0 | Keep (now used for packaging). |
 | `@eslint/js` | `10.0.1` | 10.0.1 | 0 | Keep. |
 | `@rollup/plugin-commonjs` | `29.0.3` | 29.0.3 | 0 | Keep. |
@@ -65,9 +65,30 @@ The remaining "Category should match plugin name" warning is intentional
 Pinned `actions/checkout` to v7 (`9c091bb…`) across `ci.yml`,
 `release-on-merge.yml`, and `validate-manifest.yml`.
 
+### Node runtime alignment: Node 20 → Node 24 (manifest)
+Investigation of the `@types/node` question revealed the toolchain was a major
+ahead of the declared runtime: `manifest.json` declared `Nodejs.Version: "20"`
+while the dev toolchain used `@tsconfig/node24` + `@types/node@24` + CI Node 24.
+The `@elgato/schemas` manifest schema gates the runtime by the Stream Deck
+`Software.MinimumVersion`:
+- `Nodejs.Version` may only be `"24"` when `MinimumVersion` ≥ **7.1** (anything
+  6.4–7.0 forces `"20"`).
+- The schema's `MinimumVersion` branches **7.1, 7.2, 7.3, 7.4 are identical** —
+  raising the minimum above 7.1 unlocks no additional manifest capability.
+- There is no Node 26 runtime; the only published runtimes are 20 and 24.
+
+Resolution: bumped `Software.MinimumVersion` `6.6 → 7.1` and `Nodejs.Version`
+`20 → 24`, so the manifest runtime now matches the node24 toolchain. Trade-off:
+drops support for Stream Deck **6.6–7.0**. The Elgato npm packages were already
+current (`@elgato/streamdeck` 2.1.0, `@elgato/cli` 1.7.4, `@elgato/schemas`
+0.4.15, `@elgato-stream-deck/node` 7.6.3; `SDKVersion` stays 2 — no v3 exists),
+so no library upgrade was needed.
+
 ## Deferred / left to Renovate
-- `@types/node` major (24 → 26): held intentionally (see table). Note Renovate's
-  `/^@types//` automerge rule would otherwise bump this; revisit that rule if the
-  major lands unexpectedly.
+- `@types/node` major (24 → 26): held intentionally (see table) — pinned to the
+  Node 24 runtime, not the latest release. **Renovate's `/^@types//` automerge
+  rule would otherwise bump this to 26**, breaking the runtime alignment; that
+  rule should be scoped to exclude `@types/node` (or pin `@types/node` major) so
+  it tracks the manifest's Node version instead.
 - The previous Renovate `packageRule` blocking `archiver` major upgrades was
   removed, since `archiver` is no longer a dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.nathanm412.vumeter",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.nathanm412.vumeter",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@elgato-stream-deck/node": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nathanm412.vumeter",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Real-time stereo VU meter with gradient key fills and touch display support. Designed for Stream Deck Plus with keypad and touch strip display modes.",
   "main": "com.nathanm412.vumeter.sdPlugin/bin/plugin.js",
   "scripts": {

--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,16 @@
         "/vitest/",
         "/prettier/"
       ]
+    },
+    {
+      "description": "Pin @types/node to the major matching the plugin's Node runtime (manifest Nodejs.Version, currently 24). Stream Deck only ships Node 20/24 runtimes, so a major bump (e.g. to 26) would type-check against APIs absent at runtime. Bump this in lockstep with manifest Nodejs.Version.",
+      "matchPackageNames": [
+        "@types/node"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #114. While reviewing the `@types/node` decision in `docs/dependency-review.md`, it turned out the dev toolchain (`@tsconfig/node24` + `@types/node@24` + CI Node 24) was a full major **ahead** of the runtime the plugin actually declares (`manifest.json` `Nodejs.Version: "20"`). This aligns them by moving the runtime up to Node 24.

## Why not Node 26?
Stream Deck only ships **Node 20 or Node 24** runtimes — the `@elgato/schemas` manifest schema enumerates `Nodejs.Version` as `["20","24"]`. There is no Node 26 runtime, so `@types/node@26` / `@tsconfig/node26` would type-check against APIs that don't exist when the plugin runs.

## Why MinimumVersion 7.1 (not higher)
The schema gates the runtime by `Software.MinimumVersion`:
- `Nodejs.Version: "24"` is only allowed at `MinimumVersion` **≥ 7.1** (6.4–7.0 force `"20"`).
- The `7.1`, `7.2`, `7.3`, `7.4` branches are **identical** at the manifest level, so raising the minimum past 7.1 drops more users for zero added capability.

## Changes
- **manifest.json**: `Nodejs.Version` `20 → 24`; `Software.MinimumVersion` `6.6 → 7.1`.
- **renovate.json**: block `@types/node` major bumps so it stays pinned to the runtime's Node major (otherwise the `/^@types//` automerge rule would push it to 26 and break the alignment). Bump it in lockstep with the manifest's Node version.
- **docs/dependency-review.md**: corrected the `@types/node` rationale (pinned to the Node 24 *runtime*, not the latest release) and recorded the schema/runtime analysis.
- **README.md / CLAUDE.md**: prerequisites updated to Node 24 / Stream Deck 7.1+.
- Version bumped to **1.3.0** (minor — narrows supported Stream Deck range).

## ⚠️ Compatibility impact
Raising `MinimumVersion` to 7.1 **drops support for Stream Deck 6.6–7.0**. Users on those versions won't be able to run the plugin.

## Verification
- `streamdeck pack` validates cleanly under Node 24 / 7.1 (only the pre-existing, intentional "Category should match plugin name" warning).
- `npm run typecheck`, `lint`, `test`, `build`, `pack` all pass.
- Packaged artifact carries `MinimumVersion 7.1` / `Nodejs 24` / `Version 1.3.0.0` and contains no source maps / `.d.ts`.
- Not exercised: a real-hardware smoke test on the Node 24 runtime (CI can't run the Stream Deck app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsaeW46zN4dJkKtwSHdJMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsaeW46zN4dJkKtwSHdJMq)_